### PR TITLE
PHP Example results in Fatal error when downloading files larger than the allocated memory of the script

### DIFF
--- a/php/main.php
+++ b/php/main.php
@@ -95,16 +95,7 @@ class SFTPClient
 
     $sftp = $this->sftp;
     $realpath = ssh2_sftp_realpath($sftp, $remote_file);
-    $stream = @fopen("ssh2.sftp://$sftp$realpath", 'r');
-    if (! $stream)
-      throw new Exception("Could not open file: $realpath");
-    
-    $local = fopen($local_file, "w");
-    while(!feof($stream)){
-      fwrite($local, fread($stream, 8192));
-    }
-    @fclose($stream);
-    @fclose($local);
+    ssh2_scp_recv($this->connection, $remote_file, $local_file);
   }
 
   // Delete remote file

--- a/php/main.php
+++ b/php/main.php
@@ -98,9 +98,13 @@ class SFTPClient
     $stream = @fopen("ssh2.sftp://$sftp$realpath", 'r');
     if (! $stream)
       throw new Exception("Could not open file: $realpath");
-    $contents = fread($stream, filesize("ssh2.sftp://$sftp$realpath"));
-    file_put_contents ($local_file, $contents);
+    
+    $local = fopen($local_file, "w");
+    while(!feof($stream)){
+      fwrite($local, fread($stream, 8192));
+    }
     @fclose($stream);
+    @fclose($local);
   }
 
   // Delete remote file


### PR DESCRIPTION
The current implementation attempts to open a remote stream and use `file_put_contents` to write the file to a local path. 

Any files larger than the allocated memory set in php.ini or at runtime will result in out of memory fatal errors.

I suggest this is changed to fwrite instead, with the stream being read&written at smaller chunks.